### PR TITLE
Fix: Corrected JSON syntax error in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "framer-motion": "^12.19.2",
     "lucide-react": "^0.525.0",
     "next": "15.3.4",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
     "bcrypt": "^6.0.0",
     "bcryptjs": "^3.0.2",
     "cookie": "^1.0.2",


### PR DESCRIPTION
This PR fixes a JSON syntax error in package.json that prevented npm install from working properly. It happened From my Last merge, Ensures Sam can install dependencies without issues.